### PR TITLE
Add testing plan documentation

### DIFF
--- a/Arcitecture_Guide_README.md
+++ b/Arcitecture_Guide_README.md
@@ -56,3 +56,7 @@ Below is a short description of each file inside `src/`:
 - When adding new features keep the preference for functional patterns from `fp-ts` in mind (e.g. use `Option` instead of `null`).
 - After modifying TypeScript files, run `npm run build` and `npm run bookmarklet` to regenerate the bookmarklet output.
 
+
+## Testing
+
+See `Testing_Plan_README.md` for recommended libraries and example checks. Jest with `fast-check` is used for property based tests.

--- a/Testing_Plan_README.md
+++ b/Testing_Plan_README.md
@@ -1,0 +1,65 @@
+# Testing Plan
+
+This guide explains how to verify the functionality of the Beacon overlay modules.
+
+## Setup
+
+Install the following development dependencies:
+
+```bash
+npm install --save-dev jest ts-jest @types/jest fast-check jsdom @types/jsdom
+```
+
+`ts-jest` compiles TypeScript sources while `jsdom` provides a DOM for tests that
+interact with browser APIs.
+
+Add the following script to `package.json` to run the tests:
+
+```json
+"test": "jest"
+```
+
+## Property Based Testing
+
+Use [`fast-check`](https://github.com/dubzzz/fast-check) with Jest for functions
+that produce random values. Property tests help ensure the statistical behaviour
+of dice rolls is correct.
+
+## Module Guidelines
+
+### `src/random.ts`
+- Property: `rollDie(n)` always returns an integer between `1` and `n`.
+- Optionally check distribution over many runs.
+
+### `src/rollPair.ts`
+- When `useLuck` is `false` the `luck` field should be `None`.
+- When `useLuck` is `true` the `luck` value is between `1` and `4`.
+- `base` is always between `1` and `20`.
+
+### `src/outcome.ts`
+- `chosenSum` equals `chosenBase` plus `chosenLuck` (or `0` if `None`).
+- With advantage enabled the `chosenSum` should be the maximum total of the two
+  underlying rolls.
+
+### `src/rollSkillCheck.ts`
+- Using a `jsdom` environment, verify that calling the function creates the
+  expected chat message string and triggers the appropriate DOM events.
+
+### `src/form-builder.js`
+- Ensure the form is built with all expected fields and that submitting the form
+  passes correctly formatted parameters to `rollSkillCheck`.
+
+### `src/ui-styles.js`
+- Verify that `injectDarkThemeStyles` adds a `<style>` element containing the
+  dark theme rules.
+
+## Running Tests
+
+Execute all tests with:
+
+```bash
+npm test
+```
+
+Property based checks will run alongside regular unit tests, providing confidence
+that random behaviours stay within the specified bounds.


### PR DESCRIPTION
## Summary
- document how to test each module in `Testing_Plan_README.md`
- reference the new testing plan from the architecture guide

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_686d9d4f96c483279f7b554976bf6b06