### PR TITLE
Add automated Jest tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/Arcitecture_Guide_README.md
+++ b/Arcitecture_Guide_README.md
@@ -60,3 +60,4 @@ Below is a short description of each file inside `src/`:
 ## Testing
 
 See `Testing_Plan_README.md` for recommended libraries and example checks. Jest with `fast-check` is used for property based tests.
+Unit test files reside in the `tests/` directory and can be executed with `npm test` which runs Jest using the configuration in `jest.config.js`.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      useESM: false,
+      tsconfig: {
+        module: 'CommonJS',
+        allowJs: true
+      }
+    }
+  },
+  transform: {
+    '^.+\\.(ts|js)$': 'ts-jest'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "build": "esbuild src/main.ts --bundle --minify --target=es6 --format=iife --outfile=dist/bookmarklet.js",
-    "bookmarklet": "node build-bookmarklet.js"
+    "bookmarklet": "node build-bookmarklet.js",
+    "test": "jest"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/src/outcome.ts
+++ b/src/outcome.ts
@@ -6,7 +6,7 @@ import { some, none, fold } from 'fp-ts/Option'
 
 /** Helper: sum of base + luck (0 if none) */
 const total = (p: RollPair): number =>
-  fold(
+  fold<number, number>(
     () => p.base,
     (luck) => p.base + luck
   )(p.luck)
@@ -19,8 +19,8 @@ const formatAdvantageDetails = (
 ): string => {
   const sumChosen = total(chosen)
   const sumOther  = total(other)
-  const luckChosen = fold(() => 0, (l) => l)(chosen.luck)
-  const luckOther  = fold(() => 0, (l) => l)(other.luck)
+  const luckChosen = fold<number, number>(() => 0, (l) => l)(chosen.luck)
+  const luckOther  = fold<number, number>(() => 0, (l) => l)(other.luck)
 
   return `Advantage: ${label} used ` +
     `(Base: ${chosen.base}, Luck: ${luckChosen} = ${sumChosen}; ` +

--- a/tests/form-builder.test.ts
+++ b/tests/form-builder.test.ts
@@ -1,0 +1,45 @@
+// @ts-ignore
+import { buildRollForm } from '../src/form-builder.js'
+import { rollSkillCheck } from '../src/rollSkillCheck'
+import { JSDOM } from 'jsdom'
+
+jest.mock('../src/rollSkillCheck')
+const mockRollSkillCheck = rollSkillCheck as jest.MockedFunction<typeof rollSkillCheck>
+
+let dom: JSDOM
+beforeEach(() => {
+  dom = new JSDOM('<!DOCTYPE html><html><body></body></html>')
+  ;(global as any).window = dom.window
+  ;(global as any).document = dom.window.document
+  ;(global as any).Event = dom.window.Event
+  document.body.innerHTML = ''
+  mockRollSkillCheck.mockClear()
+})
+
+test('buildRollForm creates fields and submits params', () => {
+  buildRollForm([{ label: 'Atk', default: 2 }])
+
+  const form = document.getElementById('customRollForm') as HTMLFormElement
+  expect(form).toBeTruthy()
+
+  ;(document.getElementById('characterName') as HTMLInputElement).value = 'Bob'
+  ;(document.getElementById('skillName') as HTMLInputElement).value = 'Arcana'
+  ;(document.getElementById('customTitle') as HTMLInputElement).value = 'Spell'
+  ;(document.getElementById('useluck') as HTMLInputElement).checked = true
+  ;(document.getElementById('advantage') as HTMLInputElement).checked = false
+
+  const row = document.querySelector('.static-modifier-row')!
+  ;(row.querySelector('.mod-name') as HTMLInputElement).value = 'Atk'
+  ;(row.querySelector('.mod-value') as HTMLInputElement).value = '2'
+
+  form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+
+  expect(mockRollSkillCheck).toHaveBeenCalledWith({
+    characterName: 'Bob',
+    skillName: 'Arcana',
+    customTitle: 'Spell',
+    useLuck: true,
+    advantage: false,
+    staticModifiers: [{ name: 'Atk', value: 2 }]
+  })
+})

--- a/tests/outcome.test.ts
+++ b/tests/outcome.test.ts
@@ -1,0 +1,25 @@
+import { getRollOutcome } from '../src/outcome'
+import { rollPair } from '../src/rollPair'
+import { some, none } from 'fp-ts/Option'
+
+jest.mock('../src/rollPair')
+const mockRollPair = rollPair as jest.MockedFunction<typeof rollPair>
+
+test('getRollOutcome sums base and luck', () => {
+  mockRollPair.mockReturnValueOnce({ base: 5, luck: some(3) })
+  const result = getRollOutcome(true, false)
+  expect(result.chosenBase).toBe(5)
+  expect(result.chosenLuck).toEqual(some(3))
+  expect(result.chosenSum).toBe(8)
+  expect(result.advantageDetails._tag).toBe('None')
+})
+
+test('getRollOutcome selects higher total with advantage', () => {
+  mockRollPair.mockReturnValueOnce({ base: 4, luck: none })
+  mockRollPair.mockReturnValueOnce({ base: 6, luck: none })
+  const result = getRollOutcome(false, true)
+  expect(result.chosenBase).toBe(6)
+  expect(result.chosenLuck).toEqual(none)
+  expect(result.chosenSum).toBe(6)
+  expect(result.advantageDetails._tag).toBe('Some')
+})

--- a/tests/random.test.ts
+++ b/tests/random.test.ts
@@ -1,0 +1,12 @@
+import { rollDie } from '../src/random'
+import fc from 'fast-check'
+
+test('rollDie returns value within range', () => {
+  fc.assert(
+    fc.property(fc.integer({min: 1, max: 100}), sides => {
+      const result = rollDie(sides)
+      expect(result).toBeGreaterThanOrEqual(1)
+      expect(result).toBeLessThanOrEqual(sides)
+    })
+  )
+})

--- a/tests/rollPair.test.ts
+++ b/tests/rollPair.test.ts
@@ -1,0 +1,20 @@
+import { rollPair } from '../src/rollPair'
+import fc from 'fast-check'
+
+test('rollPair respects useLuck flag and ranges', () => {
+  fc.assert(
+    fc.property(fc.boolean(), useLuck => {
+      const pair = rollPair(useLuck)
+      expect(pair.base).toBeGreaterThanOrEqual(1)
+      expect(pair.base).toBeLessThanOrEqual(20)
+      if (useLuck) {
+        expect(pair.luck._tag).toBe('Some')
+        const value = (pair.luck as any).value
+        expect(value).toBeGreaterThanOrEqual(1)
+        expect(value).toBeLessThanOrEqual(4)
+      } else {
+        expect(pair.luck._tag).toBe('None')
+      }
+    })
+  )
+})

--- a/tests/rollSkillCheck.test.ts
+++ b/tests/rollSkillCheck.test.ts
@@ -1,0 +1,49 @@
+import { rollSkillCheck } from '../src/rollSkillCheck'
+import { getRollOutcome } from '../src/outcome'
+import { none } from 'fp-ts/Option'
+import { JSDOM } from 'jsdom'
+
+jest.mock('../src/outcome')
+const mockGetRollOutcome = getRollOutcome as jest.MockedFunction<typeof getRollOutcome>
+
+let dom: JSDOM
+beforeEach(() => {
+  dom = new JSDOM('<!DOCTYPE html><html><body></body></html>')
+  ;(global as any).window = dom.window
+  ;(global as any).document = dom.window.document
+  ;(global as any).Event = dom.window.Event
+  ;(global as any).KeyboardEvent = dom.window.KeyboardEvent
+  document.body.innerHTML = `
+    <div id="textchat-input"><textarea></textarea></div>
+    <button id="chatSendBtn"></button>
+  `
+  mockGetRollOutcome.mockReset()
+})
+
+test('rollSkillCheck sends formatted chat message', () => {
+  mockGetRollOutcome.mockReturnValue({
+    chosenBase: 10,
+    chosenLuck: none,
+    chosenSum: 10,
+    advantageDetails: none
+  })
+
+  const textarea = document.querySelector<HTMLTextAreaElement>('#textchat-input textarea')!
+  const spyInput = jest.spyOn(textarea, 'dispatchEvent')
+  const sendBtn = document.querySelector<HTMLButtonElement>('#chatSendBtn')!
+  const spyClick = jest.spyOn(sendBtn, 'click')
+
+  rollSkillCheck({
+    characterName: 'Alice',
+    skillName: 'Stealth',
+    customTitle: 'Sneak',
+    useLuck: false,
+    advantage: false,
+    staticModifiers: []
+  })
+
+  expect(textarea.value).toContain('&{template:default}')
+  expect(textarea.value).toContain('Stealth Check')
+  expect(spyInput).toHaveBeenCalled()
+  expect(spyClick).toHaveBeenCalled()
+})

--- a/tests/ui-styles.test.ts
+++ b/tests/ui-styles.test.ts
@@ -1,0 +1,19 @@
+// @ts-ignore
+import { injectDarkThemeStyles } from '../src/ui-styles.js'
+import { JSDOM } from 'jsdom'
+
+let dom: JSDOM
+beforeEach(() => {
+  dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>')
+  ;(global as any).window = dom.window
+  ;(global as any).document = dom.window.document
+  ;(global as any).Event = dom.window.Event
+  document.head.innerHTML = ''
+})
+
+test('injectDarkThemeStyles inserts style element', () => {
+  injectDarkThemeStyles()
+  const style = document.head.querySelector('style')
+  expect(style).toBeTruthy()
+  expect(style!.textContent).toContain('#roll-helper-form')
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ES6",
     "moduleResolution": "Node",
     "esModuleInterop": true,
+    "allowJs": true,
     "strict": true,
     "outDir": "./dist"
   },


### PR DESCRIPTION
## Summary
- add Jest config and ignore build artifacts
- implement property-based and DOM interaction tests
- enable JS sources in the TypeScript build
- tweak outcome fold generics for strict mode
- document running tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686da0d5ed44832789360546ab86d3ac