### PR TITLE
Add skill dropdown with custom option

### DIFF
--- a/Arcitecture_Guide_README.md
+++ b/Arcitecture_Guide_README.md
@@ -35,6 +35,7 @@ Below is a short description of each file inside `src/`:
 
 - **main.ts** – Entrypoint. Imports `buildRollForm` and launches the overlay UI with default static modifiers.
 - **form-builder.js** – Builds the in-page form, handles user interactions, and wires the "Roll" button to `rollSkillCheck`.
+- **skill-options.js** – Defines the hard coded list of skills shown in the form.
 - **ui-styles.js** – Contains visual styles and helpers like `injectDarkThemeStyles` used by the form builder.
 - **random.ts** – Utility to roll a die of a specified size.
 - **rollPair.ts** – Generates a roll result (base d20, optional luck) and any confirmation chain for critical values.

--- a/src/form-builder.js
+++ b/src/form-builder.js
@@ -1,6 +1,7 @@
 // src/form-builder.js
 import { topLeftStyle, injectDarkThemeStyles } from './ui-styles.js';
 import { rollSkillCheck } from './rollSkillCheck.ts';
+import { skillOptions } from './skill-options.js';
 
 export function buildRollForm(config = []) {
   injectDarkThemeStyles();
@@ -44,8 +45,49 @@ export function buildRollForm(config = []) {
     form.appendChild(wrapper);
   }
 
+  function createSkillField(defaultValue = '') {
+    const wrapper = document.createElement('div');
+    const label = document.createElement('label');
+    label.textContent = 'Skill Name: ';
+    const input = document.createElement('input');
+    input.id = 'skillName';
+    input.setAttribute('list', 'skillList');
+    input.value = defaultValue;
+    input.style.width = '100%';
+    input.style.marginBottom = '4px';
+    label.appendChild(input);
+    wrapper.appendChild(label);
+
+    const list = document.createElement('datalist');
+    list.id = 'skillList';
+    skillOptions.forEach(opt => {
+      const option = document.createElement('option');
+      option.value = opt;
+      list.appendChild(option);
+    });
+    wrapper.appendChild(list);
+
+    const custom = document.createElement('input');
+    custom.id = 'customSkillName';
+    custom.placeholder = 'Custom Skill';
+    custom.style.width = '100%';
+    custom.style.marginTop = '4px';
+    custom.style.display = 'none';
+    wrapper.appendChild(custom);
+
+    input.addEventListener('input', () => {
+      if (input.value.trim().toLowerCase() === 'other') {
+        custom.style.display = '';
+      } else {
+        custom.style.display = 'none';
+      }
+    });
+
+    form.appendChild(wrapper);
+  }
+
   createField('Character Name', 'characterName', 'Vail');
-  createField('Skill Name', 'skillName', 'Tech');
+  createSkillField('Tech');
   createField('Roll Title', 'customTitle', '');
 
   // Static modifiers area
@@ -87,9 +129,16 @@ export function buildRollForm(config = []) {
       value: +row.querySelector('.mod-value').value || 0
     })).filter(m => m.name && m.value !== 0);
 
+    const dropdownValue = document.getElementById('skillName').value.trim();
+    const custom = document.getElementById('customSkillName');
+    const skill =
+      dropdownValue.toLowerCase() === 'other'
+        ? custom.value.trim()
+        : dropdownValue;
+
     rollSkillCheck({
       characterName: document.getElementById('characterName').value.trim(),
-      skillName: document.getElementById('skillName').value.trim(),
+      skillName: skill,
       customTitle: document.getElementById('customTitle').value.trim(),
       useLuck: document.getElementById('useluck').checked,
       advantage: document.getElementById('advantage').checked,

--- a/src/skill-options.js
+++ b/src/skill-options.js
@@ -1,0 +1,7 @@
+export const skillOptions = [
+  'Stealth',
+  'Jump',
+  'Arcana',
+  'Tech',
+  'Other'
+];

--- a/tests/form-builder.test.ts
+++ b/tests/form-builder.test.ts
@@ -21,6 +21,7 @@ test('buildRollForm creates fields and submits params', () => {
 
   const form = document.getElementById('customRollForm') as HTMLFormElement
   expect(form).toBeTruthy()
+  expect(document.getElementById('skillList')).toBeTruthy()
 
   ;(document.getElementById('characterName') as HTMLInputElement).value = 'Bob'
   ;(document.getElementById('skillName') as HTMLInputElement).value = 'Arcana'
@@ -42,4 +43,23 @@ test('buildRollForm creates fields and submits params', () => {
     advantage: false,
     staticModifiers: [{ name: 'Atk', value: 2 }]
   })
+})
+
+test('selecting Other uses custom skill name', () => {
+  buildRollForm([])
+
+  const form = document.getElementById('customRollForm') as HTMLFormElement
+  ;(document.getElementById('characterName') as HTMLInputElement).value = 'Ann'
+  const skillInput = document.getElementById('skillName') as HTMLInputElement
+  const customInput = document.getElementById('customSkillName') as HTMLInputElement
+
+  skillInput.value = 'Other'
+  skillInput.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }))
+  customInput.value = 'Athletics'
+
+  form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+
+  expect(mockRollSkillCheck).toHaveBeenCalledWith(
+    expect.objectContaining({ skillName: 'Athletics' })
+  )
 })


### PR DESCRIPTION
## Summary
- add a `skill-options.js` module for known skills
- update the form builder to offer a datalist dropdown and custom field
- support 'Other' skill entry when submitting
- document new file in architecture guide
- test the new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686db54dde088327883459ac6437e68d